### PR TITLE
identities association use omniauth_identities_account_id_column as key

### DIFF
--- a/lib/rodauth/features/omniauth.rb
+++ b/lib/rodauth/features/omniauth.rb
@@ -204,6 +204,6 @@ end
 
 if defined?(Rodauth::Model)
   Rodauth::Model.register_association(:omniauth) do
-    { name: :identities, type: :many, table: omniauth_identities_table, key: omniauth_identities_id_column }
+    { name: :identities, type: :many, table: omniauth_identities_table, key: omniauth_identities_account_id_column }
   end
 end


### PR DESCRIPTION
Hello,

Following #10, if I understand the code right, the association should be on the foreign key, not the primary.

In your test it works, because the first user has the id `1` as the identity, but otherwise it's not able to find the record or it loads an identity of another account.

I'm not sure how to write a proper test for this though.