### PR TITLE
Call `before/after_create_account` if `before/after_omniauth_create_account` is not provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ Currently, provider login is required to return the user's email address, and ac
 | `before_omniauth_callback_route` | Run arbitrary code before handling the callback route. |
 | `omniauth_identity_insert_hash` | Hash of column values used for creating a new identity on login. |
 | `omniauth_identity_update_hash` | Hash of column values used fro updating existing identities on login. |
-| `before_omniauth_create_account` | Any actions to take before creating a new account on OmniAuth login. |
-| `after_omniauth_create_account` | Any actions to take after creating a new account on OmniAuth login. |
+| `before_omniauth_create_account` | Any actions to take before creating a new account on OmniAuth login. It calls `before_create_account` if not provided.  |
+| `after_omniauth_create_account` | Any actions to take after creating a new account on OmniAuth login. It calls `after_create_account` if not provided. |
 | `omniauth_setup` | Hook for OmniAuth setup phase |
 | `omniauth_request_validation_phase` | Hook for OmniAuth request validation phase (defaults to CSRF protection). |
 | `omniauth_before_request_phase` | Hook for OmniAuth before request phase. |

--- a/lib/rodauth/features/omniauth.rb
+++ b/lib/rodauth/features/omniauth.rb
@@ -4,7 +4,7 @@ require "omniauth"
 
 module Rodauth
   Feature.define(:omniauth, :Omniauth) do
-    depends :omniauth_base, :login
+    depends :omniauth_base, :login, :create_account
 
     before :omniauth_callback_route
     before :omniauth_create_account
@@ -161,6 +161,14 @@ module Rodauth
 
     def omniauth_create_account?
       true
+    end
+
+    def _before_omniauth_create_account
+      before_create_account
+    end
+
+    def _after_omniauth_create_account
+      after_create_account
     end
 
     def omniauth_create_account

--- a/test/omniauth_test.rb
+++ b/test/omniauth_test.rb
@@ -296,7 +296,26 @@ describe "Rodauth omniauth feature" do
     rodauth do
       enable :omniauth
       omniauth_provider :developer
+      before_create_account { fail "should not be called" }
       before_omniauth_create_account { account[:name] = omniauth_info[:name] }
+    end
+    roda do |r|
+      r.rodauth
+      r.root { view content: rodauth.authenticated_by.join(",") }
+    end
+
+    omniauth_login "/auth/developer", name: "Name", email: "janko@other.com"
+    account = DB[:accounts].order(:id).last
+    assert_equal "Name", account[:name]
+  end
+
+  it "calls before_create_account by default" do
+    DB.add_column :accounts, :name, String
+
+    rodauth do
+      enable :omniauth
+      omniauth_provider :developer
+      before_create_account { account[:name] = omniauth_info[:name] }
     end
     roda do |r|
       r.rodauth


### PR DESCRIPTION
Since it uses the `login` plugin, our `after_login` continues to work as expected when we introduce the `rodauth-omniauth` plugin to our application.

However, since `rodauth-omniauth` defines its own `new_account` and `save_account` methods, we need to override
`before/after_omniauth_create_account`.

I think it would be better if the `rodauth-omniauth` plugin called `before/after_create_account` when
`before/after_omniauth_create_account` is not provided.

This change will help integrate the `rodauth-omniauth` plugin into existing applications without extra work.

In the next steps, `rodauth-omniauth` may also call `new_account` and `save_account` from Rodauth. These methods look very similar to the original `new_account` and `save_account` methods in Rodauth.