### PR TITLE
Run builder hooks only for rodauth

### DIFF
--- a/lib/rodauth/features/omniauth_base.rb
+++ b/lib/rodauth/features/omniauth_base.rb
@@ -108,7 +108,7 @@ module Rodauth
       )
       builder.configure do |config|
         [:request_validation_phase, :before_request_phase, :before_callback_phase, :on_failure].each do |hook|
-          config.send(:"#{hook}=", -> (env) { env["rodauth.omniauth.instance"].send(:"omniauth_#{hook}") })
+          config.send(:"#{hook}=", -> (env) { env["rodauth.omniauth.instance"].send(:"omniauth_#{hook}") if env["rodauth.omniauth.instance"] })
         end
       end
       self.class.instance_variable_get(:@omniauth_providers).each do |(provider, *args)|


### PR DESCRIPTION
@janko I am not sure, this is a proper fix, but I want to explain the problem and maybe you will suggest a better solution.

I had the following setup:
- Rails 8
- Rodauth
- OmniAuth used to connect third-party services (e.g. Slack), not for the authentication.

I added `rodauth-omniauth` and configured the Google provider. Now the Google authentication works perfecly, but when I try to connect Slack or anything else configured outside Rodauth, I am getting the error below.

<img width="1025" height="603" alt="Screenshot 2025-07-11 at 09 21 41" src="https://github.com/user-attachments/assets/e0f7de29-c7f5-4e06-ad34-48d72b0bd141" />

In my opinion, this happens because the `env["rodauth.omniauth.instance"]` does not exist for OmniAuth configurations outside Rodauth.
